### PR TITLE
NUT-3192 replace on_report method

### DIFF
--- a/lib/minitest/reporters/nutrio_reporter.rb
+++ b/lib/minitest/reporters/nutrio_reporter.rb
@@ -5,7 +5,6 @@ module Minitest
 
     class NutrioReporter < DefaultReporter
       def on_report
-        super
         status_line = "Finished tests in %s, %.1f tests/s, %.1f assertions/s." %
           [
             Time.at(total_time).utc.strftime("%Hh %Mm %Ss"),
@@ -14,7 +13,43 @@ module Minitest
           ]
 
         puts
+        puts
         puts colored_for(suite_result, status_line)
+        puts
+
+        unless @fast_fail
+          tests.reject(&:passed?).each do |test|
+            print_failure(test)
+          end
+        end
+
+        if @slow_count > 0
+          slow_tests = tests.sort_by(&:time).reverse.take(@slow_count)
+
+          puts
+          puts "Slowest tests:"
+          puts
+
+          slow_tests.each do |test|
+            puts "%.6fs %s" % [test.time, "#{test.name}##{test.class}"]
+          end
+        end
+
+        if @slow_suite_count > 0
+          slow_suites = @suite_times.sort_by { |x| x[1] }.reverse.take(@slow_suite_count)
+
+          puts
+          puts "Slowest test classes:"
+          puts
+
+          slow_suites.each do |slow_suite|
+            puts "%.6fs %s" % [slow_suite[1], slow_suite[0]]
+          end
+        end
+
+        puts
+        print colored_for(suite_result, result_line)
+        puts
       end
     end
 

--- a/lib/minitest/reporters/version.rb
+++ b/lib/minitest/reporters/version.rb
@@ -1,5 +1,5 @@
 module Minitest
   module Reporters
-    VERSION = '1.1.13'
+    VERSION = '1.1.14'.freeze
   end
 end


### PR DESCRIPTION
Don't call `super` but instead replace the `on_report` callback with our own to avoid duplicating output timings in 2 different formats.